### PR TITLE
fix: adiciona timeout no final do checkout

### DIFF
--- a/src/pages/checkout.js
+++ b/src/pages/checkout.js
@@ -94,10 +94,11 @@ const Checkout = () => {
       }, {}),
       payables: [],
     });
-
-    setStatus(null);
-    cleanBag();
-    setStep(step => step + 1);
+    setTimeout(() => {
+      setStatus(null);
+      cleanBag();
+      setStep(step => step + 1);
+    }, 500);
   };
 
   return (


### PR DESCRIPTION
Esse timeout tem o objetivo de esperar 500ms antes de fazer a requisição getPayables